### PR TITLE
Add dima_system_instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ you don't want/need to know more:
 Using DIMA is very straight-forward.
 You only need to dependency inject a `struct dima` to where it is needed.
 The library comes with a few ready-to-use implementations of `struct dima`.
-For example see `dima_init_system()` and `dima_init_exiting_on_failure()`.
+For example see `dima_system_instance()` (or `dima_init_system()`) and
+`dima_init_exiting_on_failure()`.
 For example, this silly `range` function allows any DIMA implementation to be
 used for creating the returned array:
 
@@ -150,13 +151,12 @@ void example(struct dima *dima, size_t max_exclusive) {
 
 int main(void) {
     /* Use the memory allocation functions provided by the system. */
-    struct dima system;
-    dima_init_system(&system);
-    example(&system, 10);
+    struct dima *system_instance = dima_system_instance();
+    example(system_instance, 10);
 
     /* Decorate the system's allocator to exit with status 14 on failure. */
     struct dima_exiting_on_failure deof;
-    dima_init_exiting_on_failure(&deof, &system, 14);
+    dima_init_exiting_on_failure(&deof, system_instance, 14);
     example(dima_from_exiting_on_failure(&deof), 24);
 
     return 0;

--- a/include/dima/system.h
+++ b/include/dima/system.h
@@ -21,7 +21,8 @@
  * allocation functions where possible and uses fallback implementations when
  * necessary.
  *
- * The struct dima created by dima_init_system() is thread-safe.
+ * A struct dima initialized with dima_init_system() is thread-safe. The struct
+ * dima returned by dima_system_instance() is thread-safe.
  */
 
 #ifndef DIMA_SYSTEM_H
@@ -30,10 +31,23 @@
 #include <dima/dima.h>
 
 /**
- * Initializes the given dima to the system's allocation functions.
+ * Initializes the given dima to use the system's allocation functions.
  *
  * @param dima the structure to initialize
  */
 void dima_init_system(struct dima *dima);
+
+/**
+ * Returns a pointer to a global dima that uses the system's allocation
+ * functions.
+ *
+ * The returned dima has the same behavior as if it was initialized with
+ * dima_init_system.
+ *
+ * The returned dima is not const-qualified, because that is what the dima_*
+ * functions require. However, clients may not modify the returned dima. If
+ * modification is required, use dima_init_system with another struct dima.
+ */
+struct dima *dima_system_instance(void);
 
 #endif /* !DIMA_SYSTEM_H */

--- a/src/system.c
+++ b/src/system.c
@@ -77,7 +77,16 @@ static const struct dima_vtable vtable = {
         system_strndup,
 };
 
+static struct dima system_instance = {
+        &vtable,
+        DIMA_IS_THREAD_SAFE,
+};
+
 void dima_init_system(struct dima *dima) {
     dima->vtable = &vtable;
     dima->flags = DIMA_IS_THREAD_SAFE;
+}
+
+struct dima *dima_system_instance(void) {
+    return &system_instance;
 }

--- a/tests/eventually_failing_test.c
+++ b/tests/eventually_failing_test.c
@@ -54,9 +54,7 @@ START_TEST(test_is_not_thread_safe) {
 END_TEST
 
 START_TEST(test_is_not_thread_safe_even_if_next_is) {
-    struct dima system;
-    dima_init_system(&system);
-    dima_init_eventually_failing(&instance, &system, 2);
+    dima_init_eventually_failing(&instance, dima_system_instance(), 2);
     ck_assert_int_eq(0, dima_is_thread_safe(test_dima));
 }
 END_TEST

--- a/tests/randomly_failing_test.c
+++ b/tests/randomly_failing_test.c
@@ -41,9 +41,7 @@ START_TEST(test_does_not_exit_on_failure_even_if_next_does) {
 END_TEST
 
 START_TEST(test_is_not_thread_safe) {
-    struct dima system;
-    dima_init_system(&system);
-    dima_init_randomly_failing(&instance, &system, 0);
+    dima_init_randomly_failing(&instance, dima_system_instance(), 0);
     ck_assert_int_eq(0, dima_is_thread_safe(test_dima));
 }
 END_TEST

--- a/tests/system_test.c
+++ b/tests/system_test.c
@@ -26,6 +26,13 @@ START_TEST(test_system_is_thread_safe) {
 }
 END_TEST
 
+START_TEST(test_system_instance_is_equal_to_initialized_instance) {
+    struct dima *inst = dima_system_instance();
+    ck_assert_ptr_eq(instance.vtable, inst->vtable);
+    ck_assert_int_eq(instance.flags, inst->flags);
+}
+END_TEST
+
 void init_test_dima(void) {
     dima_init_system(&instance);
     test_dima = &instance;
@@ -33,5 +40,6 @@ void init_test_dima(void) {
 
 void add_tests(Suite *suite) {
     ADD_TEST(system_is_thread_safe);
+    ADD_TEST(system_instance_is_equal_to_initialized_instance);
     add_standard_tests(suite);
 }


### PR DESCRIPTION
It is likely that most applications will use the system's memory
allocation functions in their production configuration. Without
dima_system_instance you need to call dima_init_system on a struct dima
outside libdima. If this is done by another library, synchronization is
needed, for example using pthread_once, which is cumbersome.

It is better to manage a system dima instance inside libdima, where the
struct dima can be initialized statically.